### PR TITLE
Make structs `repr(transparent)`

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -20,7 +20,8 @@ use std::ops::CoerceUnsized;
 
 //{{{ Unique --------------------------------------------------------------------------------------
 
-/// Same as `std::ptr::Unique`, but provides a close-enough representation on stable channel.
+/// Same as `core::ptr::Unique`, but provides a close-enough representation on stable channel.
+#[repr(transparent)]
 pub struct Unique<T: ?Sized> {
     pointer: NonNull<T>,
     marker: PhantomData<T>,

--- a/src/mbox.rs
+++ b/src/mbox.rs
@@ -38,6 +38,10 @@ use free::Free;
 //{{{ Basic structure -----------------------------------------------------------------------------
 
 /// A malloc-backed box. This structure allows Rust to exchange objects with C without cloning.
+///
+/// This is a `#[repr(transparent)]` wrapper over `NonNull<T>`, so the null pointer optimization
+/// `Option<MBox<T>>` is guaranteed.
+#[repr(transparent)]
 pub struct MBox<T: ?Sized + Free>(Unique<T>);
 
 impl<T: ?Sized + Free> MBox<T> {
@@ -185,6 +189,13 @@ impl<T: ?Sized + Free + Ord> Ord for MBox<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.deref().cmp(other.deref())
     }
+}
+
+#[test]
+fn test_repr_transparent() {
+    assert_eq!(size_of::<Option<MBox<u8>>>(), size_of::<MBox<u8>>());
+    assert_eq!(size_of::<MBox<u8>>(), size_of::<&u8>());
+    assert_eq!(size_of::<Option<MBox<[u8]>>>(), size_of::<&[u8]>());
 }
 
 //}}}

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -49,10 +49,12 @@ macro_rules! impl_zero_for_sentinel {
 impl_zero_for_sentinel!(u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize isize);
 
 /// A `malloc`-backed array with an explicit sentinel at the end.
+#[repr(transparent)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct MArray<T: Sentinel>(MBox<[T]>);
 
 /// A `malloc`-backed null-terminated string (similar to `CString`).
+#[repr(transparent)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct MString(MBox<str>);
 


### PR DESCRIPTION
This brings us closer to feature-parity with [`malloced`](https://github.com/nvzqz/malloced), and is generally just a really nice thing to have.