### PR TITLE
Optionally implement `stable_deref_trait`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,12 @@ jobs:
         run: cargo fmt -- --check
       - name: Test
         run: cargo test
-      - name: Test (no-std)
+      - name: Test (no features)
         run: cargo test --no-default-features
+      - name: Test (no stable_deref_trait)
+        run: cargo test --no-default-features --features std
+      - name: Test (no-std)
+        run: cargo test --no-default-features --features stable_deref_trait
 
   platform-test:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ exclude = [".gitignore", ".github"]
 
 [dependencies]
 libc = "0.2"
-stable_deref_trait = { version = "1.0", default-features = false }
+# Feature provided as a way to cut down on dependencies
+stable_deref_trait = { version = "1.0", optional = true, default-features = false }
 
 [build-dependencies]
 rustc_version = "0.3"
 
 [features]
-default = ["std"]
+default = ["std", "stable_deref_trait"]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 #[cfg(not(feature = "std"))]
 extern crate core as std;
 extern crate libc;
+#[cfg(feature = "stable_deref_trait")]
 extern crate stable_deref_trait;
 
 pub mod free;

--- a/src/mbox.rs
+++ b/src/mbox.rs
@@ -1,5 +1,6 @@
 //! `malloc`-based Box.
 
+#[cfg(feature = "stable_deref_trait")]
 use stable_deref_trait::StableDeref;
 
 use std::cmp::Ordering;
@@ -106,6 +107,7 @@ impl<T: ?Sized + Free> Deref for MBox<T> {
     }
 }
 
+#[cfg(feature = "stable_deref_trait")]
 unsafe impl<T: ?Sized + Free> StableDeref for MBox<T> {}
 
 impl<T: ?Sized + Free> Unpin for MBox<T> {}

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -1,6 +1,7 @@
 //! Sentinel-terminated types.
 
 use libc::{c_char, strlen};
+#[cfg(feature = "stable_deref_trait")]
 use stable_deref_trait::StableDeref;
 
 use std::borrow::{Borrow, BorrowMut};
@@ -181,7 +182,9 @@ impl Deref for MString {
     }
 }
 
+#[cfg(feature = "stable_deref_trait")]
 unsafe impl<T: Sentinel> StableDeref for MArray<T> {}
+#[cfg(feature = "stable_deref_trait")]
 unsafe impl StableDeref for MString {}
 
 impl<T: Sentinel> DerefMut for MArray<T> {


### PR DESCRIPTION
Most libraries want to keep their dependency tree as minimal as possible, this allows them to do that.