### PR TITLE
Add extra warnings

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -21,7 +21,7 @@ use std::ops::CoerceUnsized;
 //{{{ Unique --------------------------------------------------------------------------------------
 
 /// Same as `std::ptr::Unique`, but provides a close-enough representation on stable channel.
-pub struct Unique<T: ?Sized> {
+pub(crate) struct Unique<T: ?Sized> {
     pointer: NonNull<T>,
     marker: PhantomData<T>,
 }
@@ -38,7 +38,7 @@ impl<T: ?Sized> Unique<T> {
     /// The `pointer`'s ownership must be transferred into the result. That is,
     /// it is no longer valid to touch `pointer` and its copies directly after
     /// calling this function.
-    pub const unsafe fn new(pointer: NonNull<T>) -> Self {
+    pub(crate) const unsafe fn new(pointer: NonNull<T>) -> Self {
         Self {
             pointer,
             marker: PhantomData,
@@ -47,7 +47,7 @@ impl<T: ?Sized> Unique<T> {
 }
 
 impl<T: ?Sized> Unique<T> {
-    pub fn as_non_null_ptr(&self) -> NonNull<T> {
+    pub(crate) fn as_non_null_ptr(&self) -> NonNull<T> {
         self.pointer
     }
 }
@@ -78,7 +78,7 @@ unsafe fn malloc_aligned(size: usize, align: usize) -> *mut c_void {
 }
 
 /// Generic malloc function.
-pub fn gen_malloc<T>(count: usize) -> NonNull<T> {
+pub(crate) fn gen_malloc<T>(count: usize) -> NonNull<T> {
     if size_of::<T>() == 0 || count == 0 {
         NonNull::dangling()
     } else {
@@ -102,7 +102,7 @@ pub fn gen_malloc<T>(count: usize) -> NonNull<T> {
 /// # Safety
 ///
 /// The `ptr` must be obtained from `malloc()` or similar C functions.
-pub unsafe fn gen_free<T>(ptr: NonNull<T>) {
+pub(crate) unsafe fn gen_free<T>(ptr: NonNull<T>) {
     if ptr != NonNull::dangling() {
         libc::free(ptr.as_ptr() as *mut c_void);
     }
@@ -113,7 +113,7 @@ pub unsafe fn gen_free<T>(ptr: NonNull<T>) {
 /// # Safety
 ///
 /// The `ptr` must be obtained from `malloc()` or similar C functions.
-pub unsafe fn gen_realloc<T>(ptr: NonNull<T>, new_count: usize) -> NonNull<T> {
+pub(crate) unsafe fn gen_realloc<T>(ptr: NonNull<T>, new_count: usize) -> NonNull<T> {
     if size_of::<T>() == 0 {
         ptr
     } else if new_count == 0 {
@@ -224,7 +224,7 @@ impl Drop for DropCounter {
 /// A test structure which panics when it is cloned.
 #[cfg(test)]
 #[derive(Default)]
-pub struct PanicOnClone(u8);
+pub(crate) struct PanicOnClone(u8);
 
 #[cfg(test)]
 impl Clone for PanicOnClone {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,10 @@
 
 #![cfg_attr(nightly_channel, feature(min_specialization, unsize, coerce_unsized))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(elided_lifetimes_in_paths)]
+#![warn(missing_docs)]
+#![deny(non_ascii_idents)]
+#![warn(unreachable_pub)]
 
 #[cfg(not(feature = "std"))]
 extern crate core as std;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 #![warn(missing_docs)]
 #![deny(non_ascii_idents)]
 #![warn(unreachable_pub)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[cfg(not(feature = "std"))]
 extern crate core as std;

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -126,6 +126,7 @@ impl MString {
         Ok(MString(mbox))
     }
 
+    /// Convert the string into an array containing null-terminated bytes.
     pub fn into_bytes(self) -> MArray<u8> {
         MArray(self.0.into_bytes())
     }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -67,10 +67,10 @@ impl<T: Sentinel> MArray<T> {
     /// passed into the result, and thus should not be used after this function returns.
     pub unsafe fn from_raw(base: *mut T) -> MArray<T> {
         let mut len = 0;
-        while *base.add(len) != T::SENTINEL {
+        while unsafe { *base.add(len) != T::SENTINEL } {
             len += 1;
         }
-        MArray(MBox::from_raw_parts(base, len + 1))
+        MArray(unsafe { MBox::from_raw_parts(base, len + 1) })
     }
 
     /// Converts into an `MBox` including the sentinel.
@@ -104,11 +104,8 @@ impl MString {
     ///
     /// The string must be valid UTF-8.
     pub unsafe fn from_raw_unchecked(base: *mut c_char) -> MString {
-        let len = strlen(base);
-        MString(MBox::from_raw_utf8_parts_unchecked(
-            base as *mut u8,
-            len + 1,
-        ))
+        let len = unsafe { strlen(base) };
+        MString(unsafe { MBox::from_raw_utf8_parts_unchecked(base as *mut u8, len + 1) })
     }
 
     /// Constructs a new malloc-backed string from a null-terminated C string. Errors with
@@ -121,8 +118,8 @@ impl MString {
     /// must be already initialized, and terminated by `'\0'`. The string's ownership is passed into
     /// the result, and thus should not be used after this function returns.
     pub unsafe fn from_raw(base: *mut c_char) -> Result<MString, Utf8Error> {
-        let len = strlen(base);
-        let mbox = MBox::from_raw_utf8_parts(base as *mut u8, len + 1)?;
+        let len = unsafe { strlen(base) };
+        let mbox = unsafe { MBox::from_raw_utf8_parts(base as *mut u8, len + 1)? };
         Ok(MString(mbox))
     }
 


### PR DESCRIPTION
Mostly my personal preferences. I know the `#![deny(unsafe_op_in_unsafe_fn)]` is noisy, but it _is_ really helpful when you want to start better documenting your unsafe code!