### PR TITLE
Update to 2018 edition, and add extra crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,15 @@ edition = "2018"
 
 license = "MIT"
 keywords = ["malloc", "free", "ffi", "box", "cstr"]
+categories = [
+    "api-bindings",
+    "development-tools::ffi",
+    "memory-management",
+    "no-std",
+    "os",
+]
 repository = "https://github.com/kennytm/mbox"
+documentation = "https://docs.rs/mbox/"
 readme = "README.md"
 description = """malloc-based box.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "mbox"
 version = "0.6.0"
 authors = ["kennytm <kennytm@gmail.com>"]
+edition = "2018"
+
 license = "MIT"
 keywords = ["malloc", "free", "ffi", "box", "cstr"]
 repository = "https://github.com/kennytm/mbox"

--- a/src/free.rs
+++ b/src/free.rs
@@ -2,7 +2,7 @@
 
 use std::ptr::{drop_in_place, NonNull};
 
-use internal::gen_free;
+use crate::internal::gen_free;
 
 /// Implemented for pointers which can be freed.
 pub trait Free {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,5 +82,5 @@ mod internal;
 pub mod mbox;
 pub mod sentinel;
 
-pub use mbox::MBox;
-pub use sentinel::{MArray, MString};
+pub use self::mbox::MBox;
+pub use self::sentinel::{MArray, MString};

--- a/src/mbox.rs
+++ b/src/mbox.rs
@@ -19,10 +19,10 @@ use std::{
     ptr::NonNull,
 };
 
-use internal::{gen_free, gen_malloc, gen_realloc, Unique};
+use crate::internal::{gen_free, gen_malloc, gen_realloc, Unique};
 
 #[cfg(test)]
-use internal::{DropCounter, PanicOnClone};
+use crate::internal::{DropCounter, PanicOnClone};
 #[cfg(test)]
 use std::iter::{once, repeat};
 #[cfg(test)]
@@ -33,7 +33,7 @@ use std::marker::Unsize;
 #[cfg(nightly_channel)]
 use std::ops::CoerceUnsized;
 
-use free::Free;
+use crate::free::Free;
 
 //{{{ Basic structure -----------------------------------------------------------------------------
 

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -14,11 +14,11 @@ use std::ops::{Deref, DerefMut};
 use std::ptr::{copy_nonoverlapping, null, null_mut, write};
 use std::str::Utf8Error;
 
-use internal::gen_malloc;
-use mbox::MBox;
+use crate::internal::gen_malloc;
+use crate::mbox::MBox;
 
 #[cfg(test)]
-use internal::DropCounter;
+use crate::internal::DropCounter;
 
 /// Implemented for types which has a sentinel value.
 pub trait Sentinel: Eq {


### PR DESCRIPTION
The current (not documented) MSRV is 1.36.0, so we shouldn't update to the 2021 edition yet.