### PR TITLE
Hide modules

### DIFF
--- a/src/free.rs
+++ b/src/free.rs
@@ -1,9 +1,9 @@
-//! Trait to instruct how to properly drop and free pointers.
-
 use std::ptr::{drop_in_place, NonNull};
 
 use internal::gen_free;
 
+/// Trait to instruct how to properly drop and free pointers.
+///
 /// Implemented for pointers which can be freed.
 pub trait Free {
     /// Drops the content pointed by this pointer and frees it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,5 +82,6 @@ mod internal;
 pub mod mbox;
 pub mod sentinel;
 
-pub use mbox::MBox;
-pub use sentinel::{MArray, MString};
+pub use self::free::Free;
+pub use self::mbox::{MBox, MSliceIntoIter};
+pub use self::sentinel::{MArray, MString, Sentinel};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,12 @@ extern crate core as std;
 extern crate libc;
 extern crate stable_deref_trait;
 
+#[doc(hidden)] // TODO: Remove `pub` as breaking change
 pub mod free;
 mod internal;
+#[doc(hidden)] // TODO: Remove `pub` as breaking change
 pub mod mbox;
+#[doc(hidden)] // TODO: Remove `pub` as breaking change
 pub mod sentinel;
 
 pub use self::free::Free;

--- a/src/mbox.rs
+++ b/src/mbox.rs
@@ -1,5 +1,3 @@
-//! `malloc`-based Box.
-
 use stable_deref_trait::StableDeref;
 
 use std::cmp::Ordering;

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -1,5 +1,3 @@
-//! Sentinel-terminated types.
-
 use libc::{c_char, strlen};
 use stable_deref_trait::StableDeref;
 


### PR DESCRIPTION
Hide `free`, `mbox` and `sentinel` modules, and instead export their contents in the top-level crate instead.

The library has few enough items that it doesn't really make sense to separate them into modules that the user has to remember.

This is not a breaking change until we actually make the modules private.